### PR TITLE
Biome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Continuous Integration
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [20.11.1]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Run linter
+        run: npm run lint

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.7.3/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "defaultBranch": "main"
+  },
+  "organizeImports": {
+    "ignore": ["assets"],
+    "enabled": true
+  },
+  "linter": {
+    "ignore": ["assets"],
+    "enabled": true,
+    "rules": {
+      "all": true,
+      "complexity": {
+        "noExcessiveCognitiveComplexity": "off",
+        "noForEach": "off"
+      },
+      "correctness": {
+        "noUndeclaredVariables": "off",
+        "noConstantCondition": "off",
+        "noUnusedVariables": "off",
+        "noUnusedImports": "off",
+        "noNodejsModules": "off",
+        "useExhaustiveDependencies": "off"
+      },
+      "style": {
+        "noDefaultExport": "off",
+        "noParameterAssign": "off",
+        "useNamingConvention": "off",
+        "noParameterProperties": "off",
+        "noNonNullAssertion": "off",
+        "useTemplate": "off",
+        "useForOf": "off",
+        "useLiteralEnumMembers": "off",
+        "useFilenamingConvention": {
+          "level": "error",
+          "options": {
+            "filenameCases": ["camelCase", "kebab-case", "PascalCase"]
+          }
+        }
+      },
+      "suspicious": {
+        "noEmptyBlockStatements": "off",
+        "noDebugger": "off",
+        "noConsoleLog": "off",
+        "noExplicitAny": "off",
+        "noAssignInExpressions": "off",
+        "noImplicitAnyLet": "off"
+      },
+      "security": {
+        "noDangerouslySetInnerHtml": "off"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "include": ["**/*.ts", "**/*.js", "**/*.jsx", "**/*.tsx", "**/*.css", "**/*.json"],
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120,
+    "ignore": [".cache", ".history", ".npm-cache", "node_modules", ".vscode", "assets"]
+  },
+  "javascript": {
+    "formatter": {
+      "enabled": true,
+      "quoteStyle": "single",
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "bracketSpacing": true,
+      "arrowParentheses": "always"
+    }
+  },
+  "json": {
+    "formatter": {
+      "enabled": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build:main": "cross-env NODE_ENV=production webpack --config ./.erb/configs/webpack.config.main.prod.babel.js",
     "build:renderer": "cross-env NODE_ENV=production webpack --config ./.erb/configs/webpack.config.renderer.prod.babel.js",
     "rebuild": "electron-rebuild",
+    "format:check": "biome check .",
+    "format:fix": "biome check . --write --unsafe",
     "lint": "cross-env NODE_ENV=development eslint . --cache --ext .js,.jsx,.ts,.tsx",
     "package": "yarn build && npx electron-builder build --publish never",
     "yarn-dedupe": "yarn-deduplicate yarn.lock",
@@ -93,6 +95,7 @@
     ]
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.8.1",
     "@electron-toolkit/tsconfig": "^1.0.1",
     "@electron/notarize": "^2.3.2",
     "@fontsource/jetbrains-mono": "^5.0.20",


### PR DESCRIPTION
Biome is generally super duper fast. It formats the entire project in just a second or two. What takes a bit longer are the rule checks, but overall it's still under 10 seconds.

> [!IMPORTANT]
> Please run `npm run format:fix` once so the file changes are in your name.

What's remaining and I haven't ignored are mostly useful a11y warnings and other small things that we may want to fix (or also ignore, up to you). I suppose the goal should be to turn on some of the rules over time when we can, and even replace some of ESLint's rules with Biome's version as it's just a lot quicker (e.g. the missing effect dependency rule). It doesn't have everything ESLint provides though, so switching entirely might not be possible (yet).